### PR TITLE
Fix Order Service DataInitializer

### DIFF
--- a/backend/order-service/src/main/java/com/ecommerce/orderservice/config/DataInitializer.java
+++ b/backend/order-service/src/main/java/com/ecommerce/orderservice/config/DataInitializer.java
@@ -1,8 +1,8 @@
 package com.ecommerce.orderservice.config;
 
+import com.ecommerce.common.event.OrderEvent.OrderStatus;
 import com.ecommerce.orderservice.model.Order;
-import com.ecommerce.orderservice.model.OrderItem;
-import com.ecommerce.orderservice.model.OrderStatus;
+import com.ecommerce.orderservice.model.OrderLineItem;
 import com.ecommerce.orderservice.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,58 +35,60 @@ public class DataInitializer {
                 Order completedOrder = Order.builder()
                     .id(UUID.randomUUID().toString())
                     .userId("user1")
-                    .status(OrderStatus.COMPLETED)
+                    .status(OrderStatus.DELIVERED) // Using the correct status from OrderEvent
                     .totalAmount(new BigDecimal("999.98"))
+                    .paymentMethod("CREDIT_CARD")
                     .createdAt(LocalDateTime.now().minusDays(5))
                     .updatedAt(LocalDateTime.now().minusDays(4))
+                    .items(new ArrayList<>()) // Initialize the list
                     .build();
                 
-                OrderItem item1 = OrderItem.builder()
-                    .id(UUID.randomUUID().toString())
+                OrderLineItem item1 = OrderLineItem.builder()
                     .productId(UUID.randomUUID().toString()) // This would need to match a real product ID in a real app
-                    .productName("Smartphone X")
+                    .name("Smartphone X")
                     .quantity(1)
                     .price(new BigDecimal("899.99"))
-                    .subtotal(new BigDecimal("899.99"))
                     .order(completedOrder)
                     .build();
                 
-                OrderItem item2 = OrderItem.builder()
-                    .id(UUID.randomUUID().toString())
+                OrderLineItem item2 = OrderLineItem.builder()
                     .productId(UUID.randomUUID().toString()) // This would need to match a real product ID in a real app
-                    .productName("Bluetooth Speaker")
+                    .name("Bluetooth Speaker")
                     .quantity(1)
                     .price(new BigDecimal("99.99"))
-                    .subtotal(new BigDecimal("99.99"))
                     .order(completedOrder)
                     .build();
                 
-                completedOrder.setOrderItems(List.of(item1, item2));
+                // Add items using addItem method to ensure bidirectional relationship
+                completedOrder.addItem(item1);
+                completedOrder.addItem(item2);
 
                 // Create a pending order
                 Order pendingOrder = Order.builder()
                     .id(UUID.randomUUID().toString())
                     .userId("user1")
-                    .status(OrderStatus.PENDING)
+                    .status(OrderStatus.PAYMENT_PENDING) // Using the correct status from OrderEvent
                     .totalAmount(new BigDecimal("1299.99"))
+                    .paymentMethod("PAYPAL")
                     .createdAt(LocalDateTime.now().minusDays(1))
                     .updatedAt(LocalDateTime.now().minusDays(1))
+                    .items(new ArrayList<>()) // Initialize the list
                     .build();
                 
-                OrderItem item3 = OrderItem.builder()
-                    .id(UUID.randomUUID().toString())
+                OrderLineItem item3 = OrderLineItem.builder()
                     .productId(UUID.randomUUID().toString()) // This would need to match a real product ID in a real app
-                    .productName("Laptop Pro")
+                    .name("Laptop Pro")
                     .quantity(1)
                     .price(new BigDecimal("1299.99"))
-                    .subtotal(new BigDecimal("1299.99"))
                     .order(pendingOrder)
                     .build();
                 
-                pendingOrder.setOrderItems(List.of(item3));
+                // Add item using addItem method to ensure bidirectional relationship
+                pendingOrder.addItem(item3);
                 
                 orderRepository.saveAll(List.of(completedOrder, pendingOrder));
-                log.info("Added sample orders");
+                log.info("Added sample orders with IDs: {} and {}", 
+                         completedOrder.getId(), pendingOrder.getId());
             } else {
                 log.info("Orders already exist. Skipping initialization.");
             }


### PR DESCRIPTION
## Problem

The DataInitializer in the order service has several issues:

1. It's using `OrderItem` class, but the actual entity class is called `OrderLineItem`
2. It's importing a local `OrderStatus` enum that doesn't exist, when it should use the one from the common package
3. The initialization isn't properly setting up the bidirectional relationship between Order and OrderLineItems
4. The status values being used don't match those available in the enum

## Changes Made

1. Changed references from `OrderItem` to `OrderLineItem` to match the actual entity model
2. Updated imports to use the correct `OrderStatus` enum from the common package
3. Fixed OrderLineItem constructor parameters to match entity structure (removed ID parameter since it's auto-generated)
4. Ensured proper relationship setup by using the `addItem` method to maintain bidirectional relationships
5. Updated status values to use valid enum values from `OrderEvent.OrderStatus`
6. Added proper initialization of the items list in the Order builder
7. Added payment method values 
8. Improved logging to include the generated order IDs

## Testing

With these changes, the DataInitializer will properly create sample orders with the correct entity relationships when the application starts, without throwing NullPointerExceptions or other errors.