### PR TITLE
Fix Payment Service DataInitializer

### DIFF
--- a/backend/payment-service/src/main/java/com/ecommerce/paymentservice/config/DataInitializer.java
+++ b/backend/payment-service/src/main/java/com/ecommerce/paymentservice/config/DataInitializer.java
@@ -1,7 +1,7 @@
 package com.ecommerce.paymentservice.config;
 
 import com.ecommerce.paymentservice.model.Payment;
-import com.ecommerce.paymentservice.model.PaymentStatus;
+import com.ecommerce.paymentservice.model.Payment.PaymentStatus;
 import com.ecommerce.paymentservice.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,12 +29,13 @@ public class DataInitializer {
             if (paymentRepository.count() == 0) {
                 log.info("No payments found. Adding sample payments.");
                 
-                // Create a successful payment
-                Payment successfulPayment = Payment.builder()
+                // Create a completed payment
+                Payment completedPayment = Payment.builder()
                     .id(UUID.randomUUID().toString())
                     .orderId(UUID.randomUUID().toString()) // This would need to match a real order ID in a real app
+                    .userId("user1") // Added userId to match with order service
                     .amount(new BigDecimal("999.98"))
-                    .status(PaymentStatus.SUCCESSFUL)
+                    .status(PaymentStatus.COMPLETED) // Changed from SUCCESSFUL to COMPLETED to match enum
                     .paymentMethod("CREDIT_CARD")
                     .transactionId(UUID.randomUUID().toString())
                     .createdAt(LocalDateTime.now().minusDays(4))
@@ -45,6 +46,7 @@ public class DataInitializer {
                 Payment pendingPayment = Payment.builder()
                     .id(UUID.randomUUID().toString())
                     .orderId(UUID.randomUUID().toString()) // This would need to match a real order ID in a real app
+                    .userId("user1") // Added userId to match with order service
                     .amount(new BigDecimal("1299.99"))
                     .status(PaymentStatus.PENDING)
                     .paymentMethod("PAYPAL")
@@ -57,17 +59,18 @@ public class DataInitializer {
                 Payment failedPayment = Payment.builder()
                     .id(UUID.randomUUID().toString())
                     .orderId(UUID.randomUUID().toString()) // This would need to match a real order ID in a real app
+                    .userId("user1") // Added userId to match with order service
                     .amount(new BigDecimal("2499.99"))
                     .status(PaymentStatus.FAILED)
                     .paymentMethod("CREDIT_CARD")
                     .transactionId(UUID.randomUUID().toString())
                     .createdAt(LocalDateTime.now().minusDays(3))
                     .updatedAt(LocalDateTime.now().minusDays(3))
-                    .failureReason("Insufficient funds")
                     .build();
                 
-                paymentRepository.saveAll(List.of(successfulPayment, pendingPayment, failedPayment));
-                log.info("Added sample payments");
+                paymentRepository.saveAll(List.of(completedPayment, pendingPayment, failedPayment));
+                log.info("Added sample payments with IDs: {}, {}, and {}", 
+                         completedPayment.getId(), pendingPayment.getId(), failedPayment.getId());
             } else {
                 log.info("Payments already exist. Skipping initialization.");
             }


### PR DESCRIPTION
## Problem

The DataInitializer in the payment service has several issues that make it inconsistent with the model and other services:

1. It's using a status value `SUCCESSFUL` but the actual enum in the Payment class has `COMPLETED` instead
2. It's missing the `userId` field which exists in the Payment entity model
3. It's using a `failureReason` field which doesn't exist in the Payment model
4. The logging could be improved to be consistent with other services

## Changes Made

1. Changed payment status from `SUCCESSFUL` to `COMPLETED` to match the enum in Payment.java
2. Added `userId` field (set to "user1") to all sample payments to be consistent with the order service
3. Removed `failureReason` field which doesn't exist in Payment model
4. Improved logging to include generated payment IDs for better debugging

## Testing

With these changes, the DataInitializer in the payment service will properly create sample payments with correct fields and status values when the application starts, without throwing errors. This also ensures consistency between the order and payment services.